### PR TITLE
Update setup.md - Add instructions for running unsigned X-Plane plugin on macOS

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -42,7 +42,11 @@ This action will add **INAV Surfwing** flying wing model with this plugin.
 
 # Setup (MacOs)
 
-For MacOs, all steps are analogous to Windows.
+For MacOs, all steps are analogous to Windows, but since the X-Plane plugin is not signed, you may need to run these commands in the terminal:
+```bash
+xattr -rd com.apple.quarantine ~/Library/Application\ Support/Steam/SteamApps/common/X-Plane\ 11/Aircraft/Extra\ Aircraft/NK_FPVSurfwing/plugins/INAV-X-Plane-HITL/64/mac.xpl
+xattr -rd com.apple.quarantine ~/Library/Application\ Support/Steam/SteamApps/common/X-Plane\ 11/Aircraft/Extra\ Aircraft/NK_FPVSurfwing/plugins/xlua/64/mac.xpl
+```
 
 # Flight controller configuration
 


### PR DESCRIPTION
Just added a terminal command for running unsigned plugins on macos:
`xattr -rd com.apple.quarantine (...)`

This fix the error "cannot be opened because the developer cannot be verified".